### PR TITLE
Fix obviews error when no source view was generated

### DIFF
--- a/bin/obviews.py
+++ b/bin/obviews.py
@@ -1621,7 +1621,7 @@ def main():
 		except KeyError:
 			cls = View
 		view = cls(s, TASK)
-	if TASK.sview != None:
+	if hasattr(TASK, 'sview') and TASK.sview != None:
 		TASK.sview.ensure_data()
 	TASK.views.sort(key = lambda v: v.priority(), reverse=True)
 	for i in range(0, len(TASK.views)):


### PR DESCRIPTION
Without this patch, Obviews has a critical error if no sview.csv exists in the folder (it is optional)
Doesn't usually happen in normal flow but still