### PR TITLE
add a missing property to the Task class

### DIFF
--- a/bin/obviews.py
+++ b/bin/obviews.py
@@ -947,6 +947,7 @@ class Task:
 		self.read()
 		self.defs = None
 		self.views = []
+		self.sview = None
 
 	def get_max(self, stat):
 		return self.max.get_val(stat)


### PR DESCRIPTION
Obviews would fail to load on larger files when RocqStat was running it, the error messages it would throw were:
```
4-10-03 11:07:35,864 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] INFO: server mode enabled.
2024-10-03 11:07:35,875 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] Traceback (most recent call last):
2024-10-03 11:07:35,875 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] File "/home/alex/work/rocqstat-ng/external/obviews/bin/obviews.py", line 1659, in <module>
2024-10-03 11:07:35,875 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] main()
2024-10-03 11:07:35,875 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] File "/home/alex/work/rocqstat-ng/external/obviews/bin/obviews.py", line 1646, in main
2024-10-03 11:07:35,875 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] stat.ensure_load()
2024-10-03 11:07:35,875 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] File "/home/alex/work/rocqstat-ng/external/obviews/bin/obviews.py", line 1166, in ensure_load
2024-10-03 11:07:35,875 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] self.load()
2024-10-03 11:07:35,875 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] File "/home/alex/work/rocqstat-ng/external/obviews/bin/obviews.py", line 1153, in load
2024-10-03 11:07:35,875 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] self.task.collect(self,
2024-10-03 11:07:35,875 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] File "/home/alex/work/rocqstat-ng/external/obviews/bin/obviews.py", line 991, in collect
2024-10-03 11:07:35,875 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] g.collect(id, val, addr, size, ctx, self)
2024-10-03 11:07:35,875 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] File "/home/alex/work/rocqstat-ng/external/obviews/bin/obviews.py", line 903, in collect
2024-10-03 11:07:35,875 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] b.collect(id, val, addr, size, task)
2024-10-03 11:07:35,875 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] File "/home/alex/work/rocqstat-ng/external/obviews/bin/obviews.py", line 820, in collect
2024-10-03 11:07:35,875 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] if task.sview != None:
2024-10-03 11:07:35,876 - DEBUG - controllers.PyObviewsCtrl - [OBVIEWS] AttributeError: 'Task' object has no attribute 'sview'. Did you mean: 'views'
```
As far as I can tell, the `sview` attribute is expected in multiple places but not defined anywhere, so this PR defines it with a default value of `None`. I'm not sure what the `sview` attribute represents, or why it only becomes an issue when running Obviews on large binary/trace files through Rocqstat. 

The command that causes this error is `python -u /home/alex/work/rocqstat-ng/external/obviews/bin/obviews.py --serve --datadir /home/alex/work/rocqstat-ng/external/obviews/data/obviews /home/alex/work/rocqstat-ng/statemate/statemate_arm_cortex_M7.elf statemate_main`, and if I run that manually through my terminal it works just fine, which furthers my confusion. I'm going to try to understand what the hell is going on but if someone has a better idea than I do, please let me know.