### PR TITLE
 Use `monospace` font-face for source code display

### DIFF
--- a/bin/obviews.py
+++ b/bin/obviews.py
@@ -214,6 +214,7 @@ class CColorizer:
 			"([a-zA-Z_0-9]+)")
 
 	def colorize(self, line, out):
+		out.write("<font face='monospace'>")
 		while line:
 			m = self.re.search(line)
 			if not m:
@@ -231,6 +232,7 @@ class CColorizer:
 			else:
 				out.write(m.group())
 			line = line[m.end():]
+		out.write("</font>")
 		out.write("<br align='left'/>")
 
 SYNTAX_COLS = { ext: CColorizer \


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c4e0f36f-e732-4698-9b48-4b8e44b899b6)

![image](https://github.com/user-attachments/assets/89fdb41e-c13a-4a69-81a3-7897a4173fc7)

Fixes: https://github.com/statinf-software/rocqstat-ng/issues/1003