### PR TITLE
Make basic blocks colour themselves correctly

### DIFF
--- a/bin/obviews.py
+++ b/bin/obviews.py
@@ -1393,13 +1393,13 @@ def postprocess_svg(text):
 		# Insert javascript function call foreach node in the SVG
 		node_tag_regex = re.compile(r"(<g\s+id=(\"[^\"]*\"|'[^']*')\s+class\s*=(\"\s*node\s*\"|'\s*node\s*'))")
 		result = node_tag_regex.sub(r"\g<1> onclick='javascript:cfg_center_block_by_id(\g<2>)'",text)
-		
+
 		# Remove tooltip and title tags
 		title_tag_regex = re.compile(r"<title\b[^>]*>(.*?)</title>")
 		title_attribute_regex = re.compile(r"xlink:title=(\"[^\"]*\"|'[^']*')")
 		result = title_tag_regex.sub("",result)
 		result = title_attribute_regex.sub("",result)
-		
+
 		return result
 
 def do_function_stat(comps, query):

--- a/data/obviews/obviews.js
+++ b/data/obviews/obviews.js
@@ -292,10 +292,10 @@ function display_in_code(msg) {
 }
 
 function fill_node(node, color) {
-	if(node.children[1].tagName == "g")
-		node = node.children[1].children[0].children[0];
+	if(node.children[0].tagName == "g")
+		node = node.children[0].children[0].children[0];
 	else
-		node = node.children[1];
+		node = node.children[0];
 	node.setAttribute("fill", color);
 }
 
@@ -509,7 +509,7 @@ function clear_source_stat() {
 	t = t.children[0]
 	t.children[0].children[2].innerHTML = "";
 	for(let i = 0; i < t.childElementCount; i++) {
-		t.children[i].style.backgroundColor = "white";
+		t.children[i].style.backgroundColor = "";
 		t.children[i].children[2].innerHTML = "";
 	}
 }


### PR DESCRIPTION
What we thought was a race condition was actually Obviews colouring the name of the basic blocks, rather than their backgrounds:
![image](https://github.com/user-attachments/assets/e3d3860f-7ae5-4a62-a4fc-d1591ef880a5)
A while ago the tooltips were removed from basic blocks by removing every `<title>` element. This breaks the fill_node function in obviews.js, which changes the background colour of a basic block by referring to its index:

```js
function fill_node(node, color) {
	if(node.children[1].tagName == "g")
		node = node.children[1].children[0].children[0];
	else
		node = node.children[1];
	node.setAttribute("fill", color);
}
```

The most principled move would be to fix the fill_node function, but there might be other functions that refer to elements by index like this. This PR creates empty titles, instead of removing them entirely.